### PR TITLE
LoadingCache for AuditLogDao objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 			<artifactId>hsqldb</artifactId>
 			<version>2.3.2</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>18.0</version>
+		</dependency>
 	</dependencies>
 
 


### PR DESCRIPTION
Caches AuditLogDao objects for a specific table and expires them after more than 15min without being accessed (executes a `create table if not exists` statement in constructor).

Adds a depdendency to google guava 18.0.
